### PR TITLE
Fix typing syntax for Python 3.9 compatibility in __init__.py

### DIFF
--- a/homeharvest/__init__.py
+++ b/homeharvest/__init__.py
@@ -4,13 +4,13 @@ from .core.scrapers import ScraperInput
 from .utils import process_result, ordered_properties, validate_input, validate_dates, validate_limit
 from .core.scrapers.realtor import RealtorScraper
 from .core.scrapers.models import ListingType, SearchPropertyType, ReturnType, Property
-
+from typing import Optional, List
 
 def scrape_property(
     location: str,
     listing_type: str = "for_sale",
     return_type: str = "pandas",
-    property_type: list[str] | None = None,
+    property_type: Optional[List[str]] = None,
     radius: float = None,
     mls_only: bool = False,
     past_days: int = None,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "homeharvest"
-version = "0.4.9"
+version = "0.4.10"
 description = "Real estate scraping library"
 authors = ["Zachary Hampton <zachary@bunsly.com>", "Cullen Watson <cullen@bunsly.com>"]
 homepage = "https://github.com/Bunsly/HomeHarvest"


### PR DESCRIPTION
Hello,

I got some help from GPT to send the PR, the only adjustments made were:
"property_type: list[str] | None = None" to "property_type: Optional[List[str]] = None" and importing Optional, List from typing.
I know that this version works because a friend helped me out on this, he managed to modify this line and everything worked.

Thank you so much,
Alexandre